### PR TITLE
Initial import of code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-
+- 1.0.0
+  - Initial implementation

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012–2016 Elasticsearch <http://www.elastic.co>
+Copyright (c) 2017 Elasticsearch <http://www.elastic.co>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/logstash/integrations/internal.rb
+++ b/lib/logstash/integrations/internal.rb
@@ -1,21 +1,24 @@
 module LogStash; module Integrations; module Internal
   include ::LogStash::Util::Loggable
-
-  def self.start!
-    @inputs = java.util.concurrent.ConcurrentHashMap.new
-  end
+  
+  INPUTS = java.util.concurrent.ConcurrentHashMap.new()
 
   def self.addresses_by_run_state
-    result = {:running => [], :not_running => {}}
-    @inputs.forEach do |address, input| 
+    result = {:running => [], :not_running => []}
+    INPUTS.forEach do |address, input| 
       key = input.running? ? :running : :not_running
       result[key] << address
     end
     result
   end
 
+  # Only really useful for tests
+  def self.reset!
+    INPUTS.clear
+  end
+
   def self.send_to(address, events)
-    input = @inputs.get(address);
+    input = INPUTS.get(address);
     # Internal receive returns a boolean indicating whether the receive was successful or not
     # If the result is false then the sender will retry.
     # If this were not here we'd have a race where an input could be stopped after the CHM.get above
@@ -23,20 +26,18 @@ module LogStash; module Integrations; module Internal
     # You might think this would be solvable in a simpler way using CHM.compute {|address, input| input.internal_receive(events) }
     # but that would be problematic since `internal_receive` blocks indefinitely on pipeline backpressure
     # this is much more dependable
-    if input
-      return input.internal_receive(events)
-    end
+    return input && input.internal_receive(events)
   end
 
   # Return true if nothing was listening previously
   def self.listen(address, internal_input)
-    mapped_input = @inputs.putIfAbsent(address, internal_input).nil?
+    mapped_input = INPUTS.putIfAbsent(address, internal_input).nil?
     return mapped_input == internal_input
   end
 
   # Return true if the input was actually listening
   def self.unlisten(address, internal_input)
-    @inputs.remove(address, internal_input)
+    INPUTS.remove(address, internal_input)
   end
 
   class Input < ::LogStash::Inputs::Base
@@ -45,23 +46,23 @@ module LogStash; module Integrations; module Internal
     config :address, :validate => :string, :required => true
 
     def register
+      # May as well set this up here, writers won't do anything until
+      # @running is set to false
       @running = java.util.concurrent.atomic.AtomicBoolean.new(false)
-    end
-
-    def running?
-      @running.get()
+      Internal.listen(@address, self)
     end
 
     def run(queue)
       @queue = queue
-      Internal.listen(@address, self)
-
-      # Now that the listener is set up we can activate this
       @running.set(true)
 
       while @running.get()
         sleep 0.5
       end
+    end
+
+    def running?
+      @running.get()
     end
 
     # Returns false if the receive failed due to a stopping input
@@ -80,7 +81,7 @@ module LogStash; module Integrations; module Internal
 
     def stop
       # We stop receiving events before we unlisten to prevent races
-      @running.set(false)
+      @running.set(false) if @running # If register wasn't yet called, no @running!
       Internal.unlisten(@address, self)
     end
   end
@@ -91,16 +92,18 @@ module LogStash; module Integrations; module Internal
     config :send_to, :validate => :string, :required => true, :list => true
 
     def register
-      # Noop, needed to conform to plugin API
+      # noop, needed to obey plugin API
     end
 
     def multi_receive(events)
       @send_to.each do |address|
         while !Internal.send_to(address, events)
           sleep 1
-          @logger.info("Internal output to address waiting for listener to start",
+          @logger.info(
+            "Internal output to address waiting for listener to start",
             :destination_address => address,
-            :registered_addresses => Internal.addresses_by_run_state)
+            :registered_addresses => Internal.addresses_by_run_state
+          )
         end
       end
     end

--- a/lib/logstash/integrations/internal.rb
+++ b/lib/logstash/integrations/internal.rb
@@ -31,8 +31,7 @@ module LogStash; module Integrations; module Internal
 
   # Return true if nothing was listening previously
   def self.listen(address, internal_input)
-    mapped_input = INPUTS.putIfAbsent(address, internal_input).nil?
-    return mapped_input == internal_input
+    return INPUTS.putIfAbsent(address, internal_input).nil?
   end
 
   # Return true if the input was actually listening
@@ -49,7 +48,11 @@ module LogStash; module Integrations; module Internal
       # May as well set this up here, writers won't do anything until
       # @running is set to false
       @running = java.util.concurrent.atomic.AtomicBoolean.new(false)
-      Internal.listen(@address, self)
+      listen_successful = Internal.listen(@address, self)
+      puts "LSUCC #{listen_successful}"
+      if !listen_successful
+        raise ::LogStash::ConfigurationError, "Internal input at '#{@address}' already bound! Addresses must be globally unique across pipelines."
+      end
     end
 
     def run(queue)

--- a/lib/logstash/integrations/internal.rb
+++ b/lib/logstash/integrations/internal.rb
@@ -1,0 +1,108 @@
+module LogStash; module Integrations; module Internal
+  include ::LogStash::Util::Loggable
+
+  def self.start!
+    @inputs = java.util.concurrent.ConcurrentHashMap.new
+  end
+
+  def self.addresses_by_run_state
+    result = {:running => [], :not_running => {}}
+    @inputs.forEach do |address, input| 
+      key = input.running? ? :running : :not_running
+      result[key] << address
+    end
+    result
+  end
+
+  def self.send_to(address, events)
+    input = @inputs.get(address);
+    # Internal receive returns a boolean indicating whether the receive was successful or not
+    # If the result is false then the sender will retry.
+    # If this were not here we'd have a race where an input could be stopped after the CHM.get above
+    # but before this line.
+    # You might think this would be solvable in a simpler way using CHM.compute {|address, input| input.internal_receive(events) }
+    # but that would be problematic since `internal_receive` blocks indefinitely on pipeline backpressure
+    # this is much more dependable
+    if input
+      return input.internal_receive(events)
+    end
+  end
+
+  # Return true if nothing was listening previously
+  def self.listen(address, internal_input)
+    mapped_input = @inputs.putIfAbsent(address, internal_input).nil?
+    return mapped_input == internal_input
+  end
+
+  # Return true if the input was actually listening
+  def self.unlisten(address, internal_input)
+    @inputs.remove(address, internal_input)
+  end
+
+  class Input < ::LogStash::Inputs::Base
+    config_name "internal"
+
+    config :address, :validate => :string, :required => true
+
+    def register
+      @running = java.util.concurrent.atomic.AtomicBoolean.new(false)
+    end
+
+    def running?
+      @running.get()
+    end
+
+    def run(queue)
+      @queue = queue
+      Internal.listen(@address, self)
+
+      # Now that the listener is set up we can activate this
+      @running.set(true)
+
+      while @running.get()
+        sleep 0.5
+      end
+    end
+
+    # Returns false if the receive failed due to a stopping input
+    # To understand why this value is useful see Internal.send_to
+    def internal_receive(events)
+      return false if !@running.get()
+
+      events.each do |e| 
+        clone = e.clone
+        decorate(clone)
+        @queue << clone
+      end
+
+      return true
+    end
+
+    def stop
+      # We stop receiving events before we unlisten to prevent races
+      @running.set(false)
+      Internal.unlisten(@address, self)
+    end
+  end
+
+  class Output < ::LogStash::Outputs::Base
+    config_name "internal"
+
+    config :send_to, :validate => :string, :required => true, :list => true
+
+    def register
+      # Noop, needed to conform to plugin API
+    end
+
+    def multi_receive(events)
+      @send_to.each do |address|
+        while !Internal.send_to(address, events)
+          sleep 1
+          @logger.info("Internal output to address waiting for listener to start",
+            :destination_address => address,
+            :registered_addresses => Internal.addresses_by_run_state)
+        end
+      end
+    end
+  end
+end; end; end

--- a/lib/logstash/integrations/internal.rb
+++ b/lib/logstash/integrations/internal.rb
@@ -62,7 +62,7 @@ module LogStash; module Integrations; module Internal
     end
 
     def running?
-      @running.get()
+      @running && @running.get()
     end
 
     # Returns false if the receive failed due to a stopping input
@@ -94,13 +94,13 @@ module LogStash; module Integrations; module Internal
     def register
       # noop, needed to obey plugin API
     end
-
+    BLOCKED_LOG_MESSAGE = "Internal output to address waiting for listener to start"
     def multi_receive(events)
       @send_to.each do |address|
         while !Internal.send_to(address, events)
           sleep 1
           @logger.info(
-            "Internal output to address waiting for listener to start",
+            BLOCKED_LOG_MESSAGE,
             :destination_address => address,
             :registered_addresses => Internal.addresses_by_run_state
           )

--- a/lib/logstash/integrations/internal/input.rb
+++ b/lib/logstash/integrations/internal/input.rb
@@ -1,0 +1,48 @@
+class ::LogStash::Integrations::Internal::Input < ::LogStash::Inputs::Base
+  config_name "internal"
+
+  config :address, :validate => :string, :required => true
+
+  def register
+    # May as well set this up here, writers won't do anything until
+    # @running is set to false
+    @running = java.util.concurrent.atomic.AtomicBoolean.new(false)
+    listen_successful = ::LogStash::Integrations::Internal.listen(@address, self)
+    if !listen_successful
+      raise ::LogStash::ConfigurationError, "Internal input at '#{@address}' already bound! Addresses must be globally unique across pipelines."
+    end
+  end
+
+  def run(queue)
+    @queue = queue
+    @running.set(true)
+
+    while @running.get()
+      sleep 0.5
+    end
+  end
+
+  def running?
+    @running && @running.get()
+  end
+
+  # Returns false if the receive failed due to a stopping input
+  # To understand why this value is useful see Internal.send_to
+  def internal_receive(events)
+    return false if !@running.get()
+
+    events.each do |e| 
+      clone = e.clone
+      decorate(clone)
+      @queue << clone
+    end
+
+    return true
+  end
+
+  def stop
+    # We stop receiving events before we unlisten to prevent races
+    @running.set(false) if @running # If register wasn't yet called, no @running!
+    ::LogStash::Integrations::Internal.unlisten(@address, self)
+  end
+end

--- a/lib/logstash/integrations/internal/output.rb
+++ b/lib/logstash/integrations/internal/output.rb
@@ -5,15 +5,16 @@ class ::LogStash::Integrations::Internal::Output < ::LogStash::Outputs::Base
 
   def register
     ::LogStash::Integrations::Internal.register_sender(self, @send_to)
+    @running = java.util.concurrent.atomic.AtomicBoolean.new(true)
   end
 
-  BLOCKED_LOG_MESSAGE = "Internal output to address waiting for listener to start"
+  NO_LISTENER_LOG_MESSAGE = "Internal output to address waiting for listener to start"
   def multi_receive(events)
     @send_to.each do |address|
-      while !::LogStash::Integrations::Internal.send_to(address, events)
+      while @running.get() && !::LogStash::Integrations::Internal.send_to(address, events)
         sleep 1
         @logger.info(
-          BLOCKED_LOG_MESSAGE,
+          NO_LISTENER_LOG_MESSAGE,
           :destination_address => address,
           :registered_addresses => ::LogStash::Integrations::Internal.addresses_by_run_state
         )
@@ -22,6 +23,7 @@ class ::LogStash::Integrations::Internal::Output < ::LogStash::Outputs::Base
   end
 
   def close
+    @running.set(false) if @running
     ::LogStash::Integrations::Internal.unregister_sender(self, @send_to)
   end
 end

--- a/lib/logstash/integrations/internal/output.rb
+++ b/lib/logstash/integrations/internal/output.rb
@@ -1,0 +1,27 @@
+class ::LogStash::Integrations::Internal::Output < ::LogStash::Outputs::Base
+  config_name "internal"
+
+  config :send_to, :validate => :string, :required => true, :list => true
+
+  def register
+    ::LogStash::Integrations::Internal.register_sender(self, @send_to)
+  end
+
+  BLOCKED_LOG_MESSAGE = "Internal output to address waiting for listener to start"
+  def multi_receive(events)
+    @send_to.each do |address|
+      while !::LogStash::Integrations::Internal.send_to(address, events)
+        sleep 1
+        @logger.info(
+          BLOCKED_LOG_MESSAGE,
+          :destination_address => address,
+          :registered_addresses => ::LogStash::Integrations::Internal.addresses_by_run_state
+        )
+      end
+    end
+  end
+
+  def close
+    ::LogStash::Integrations::Internal.unregister_sender(self, @send_to)
+  end
+end

--- a/lib/logstash_registry.rb
+++ b/lib/logstash_registry.rb
@@ -1,0 +1,6 @@
+require 'logstash/integrations/internal'
+
+LogStash::Integrations::Internal.start!
+
+LogStash::PLUGIN_REGISTRY.add(:input, "internal", LogStash::Integrations::Internal::Input)
+LogStash::PLUGIN_REGISTRY.add(:output, "internal", LogStash::Integrations::Internal::Output)

--- a/lib/logstash_registry.rb
+++ b/lib/logstash_registry.rb
@@ -1,6 +1,4 @@
 require 'logstash/integrations/internal'
 
-LogStash::Integrations::Internal.start!
-
 LogStash::PLUGIN_REGISTRY.add(:input, "internal", LogStash::Integrations::Internal::Input)
 LogStash::PLUGIN_REGISTRY.add(:output, "internal", LogStash::Integrations::Internal::Output)

--- a/logstash-input-integration.gemspec
+++ b/logstash-input-integration.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-integration-internal'
-  s.version         = '0.0.1'
+  s.version         = '1.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pass events between logstash pipelines"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
This should be ready for initial review

A sample `pipelines.yml` might be: 

```
- pipeline.id: senderone
  config.string: "input { generator { message => huhx } } filter { sleep { time => 1 }} output { internal { send_to => [foo] } }"
- pipeline.id: sendertwo
  config.string: "input { generator { message => whutx } } filter { sleep { time => 1 }} output { internal { send_to => [foo] } }"
- pipeline.id: out
  config.string: " input { internal { address => foo } } output { stdout { codec => json_lines } }"
```

